### PR TITLE
fix(dark-mode): remove color scheme for dark mode

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,13 +14,3 @@ a {
 * {
   box-sizing: border-box;
 }
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-  body {
-    color: white;
-    background: black;
-  }
-}


### PR DESCRIPTION
### WHAT PROBLEM DOES THIS PR SOLVE?
dark mode on browser make inconsistency on UI.

### How does this PR solve it?
remove dark mode logic.

### Screenshots or GIFs:

**before**
<img width="1440" alt="Screen Shot 2022-08-30 at 12 17 48" src="https://user-images.githubusercontent.com/32932093/187348300-fda6fbd7-c8fb-4d51-a975-64dd1e90fcf4.png">

**after**
<img width="1440" alt="Screen Shot 2022-08-30 at 12 17 45" src="https://user-images.githubusercontent.com/32932093/187348329-281bda69-a3bc-40f0-a2fb-c2f1c91980e4.png">



